### PR TITLE
Fix build error on GCC

### DIFF
--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -861,11 +861,11 @@ void screenres(int w, int h)
 ICOMMAND(screenres, "ii", (int *w, int *h), screenres(*w, *h));
 
 static int curgamma = 100;
-VARFP(gamma, 30, 100, 300,
+VARFNP(gamma, reqgamma, 30, 100, 300,
 {
-    if(gamma == curgamma) return;
-    curgamma = gamma;
-    if(SDL_SetWindowBrightness(screen, gamma/100.0f)==-1) conoutf(CON_ERROR, "Could not set gamma: %s", SDL_GetError());
+    if(initing || reqgamma == curgamma) return;
+    curgamma = reqgamma;
+    if(SDL_SetWindowBrightness(screen, reqgamma/100.0f)==-1) conoutf(CON_ERROR, "Could not set gamma: %s", SDL_GetError());
 });
 
 void restoregamma()

--- a/shared/command.h
+++ b/shared/command.h
@@ -285,6 +285,7 @@ inline void ident::getval(tagval &v) const
 #define VARF(name, min, cur, max, body) _VARF(name, name, min, cur, max, body, 0)
 #define VARFP(name, min, cur, max, body) _VARF(name, name, min, cur, max, body, IDF_PERSIST)
 #define VARFR(name, min, cur, max, body) _VARF(name, name, min, cur, max, body, IDF_OVERRIDE)
+#define VARFNP(name, global, min, cur, max, body) _VARF(name, global, min, cur, max, body, IDF_PERSIST)
 
 #define _HVAR(name, global, min, cur, max, persist)  int global = variable(#name, min, cur, max, &global, NULL, persist | IDF_HEX)
 #define HVARN(name, global, min, cur, max) _HVAR(name, global, min, cur, max, 0)

--- a/shared/cube.h
+++ b/shared/cube.h
@@ -3,18 +3,10 @@
 
 #define _FILE_OFFSET_BITS 64
 
-#ifdef __GNUC__
-#define gamma __gamma
-#endif
-
 #ifdef WIN32
 #define _USE_MATH_DEFINES
 #endif
 #include <math.h>
-
-#ifdef __GNUC__
-#undef gamma
-#endif
 
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
Tested on Fedora 30 with GCC 9, it now builds again :smiley:

Based on Sauerbraten SVN r5361.